### PR TITLE
Workflow und die entsprechende Datei umbenannt nach „build“

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Gradle
+name: build
 
 on: [push, pull_request]
 


### PR DESCRIPTION
„build“ ist klarer als „Gradle“