### PR TITLE
Checks aufteilen auf drei einzelne Tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,5 +15,9 @@ jobs:
         java-version: 11
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
+    - name: Check with Checkstyle
+      run: ./gradlew checkstyleMain checkstyleTest
+    - name: Check with PMD
+      run: ./gradlew pmdMain pmdTest
+    - name: Check with SpotBugs
+      run: ./gradlew spotbugsMain spotbugsTest


### PR DESCRIPTION
So sieht man schneller, welches Tool den Build verhindert hat.