### PR TITLE
CSRF-Schutz wieder eingeschaltet

### DIFF
--- a/src/main/java/mops/config/SecurityConfig.java
+++ b/src/main/java/mops/config/SecurityConfig.java
@@ -69,8 +69,6 @@ class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         super.configure(http);
         forceHTTPS(http);
-        // TODO: CSRF-Protection wieder einschalten und Konflikt mit Webflow lösen (sehr, sehr wichtig!)
-        http.csrf().disable();
         http.authorizeRequests()
                 .antMatchers("/actuator/**")
                 .hasAnyRole("monitoring")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,12 +7,9 @@ spring.security.user.password=geheim
 spring.security.user.roles=USER
 
 spring.main.banner-mode=off
-#logging.level.root=trace
 
 keycloak.principal-attribute=preferred_username
 keycloak.auth-server-url=https://keycloak.cs.hhu.de/auth
 keycloak.realm=MOPS
 keycloak.resource=demo
 keycloak.public-client=true
-
-logging.level.org.springframework.security=DEBUG

--- a/src/main/resources/flows/poll-vote/poll-vote-flow.xml
+++ b/src/main/resources/flows/poll-vote/poll-vote-flow.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<flow xmlns="http://www.springframework.org/schema/webflow"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/webflow
+                      http://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd">
+
+  <secured attributes="ROLE_orga, ROLE_studentin" match="any" />
+
+  <view-state id="mobilePollVote" view="/flows/poll-vote/mobilePollVote">
+    <transition on="home" to="home"/>
+    <transition on="results" to="mobilePollResults"/>
+  </view-state>
+
+  <view-state id="mobilePollResults" view="/flows/poll-vote/mobilePollResults">
+    <transition on="vote" to="mobilePollVote"/>
+    <transition on="home" to="home"/>
+  </view-state>
+
+  <end-state id="home" view="externalRedirect:contextRelative:/"/>
+</flow>

--- a/src/main/resources/static/choiceOptions.js
+++ b/src/main/resources/static/choiceOptions.js
@@ -1,0 +1,20 @@
+let today = new Date();
+let tomorrow = new Date(today.setDate(today.getDate()+1));
+tomorrow = tomorrow.toISOString().slice(0, 10);
+
+function addChoiceOption(){
+    $('#scheduleOptionList').append(`                    <li>
+                        <div class="form-group row">
+                            <input name="dateOption" class="form-control col ml-5" type="date">
+                            <input class="form-control col ml-5" type="time" value="12:00">
+                            <div class="col-1">
+                                <button style="width: 37px; height: 37px" type="button" name="removeOption" class="btn btn-danger" onclick="removeChoiceOption(this)">-</button>
+                            </div>
+                        </div>
+                    </li>`);
+    $('#dateOption').last().value = tomorrow;
+}
+
+function removeChoiceOption(btn){
+    $(btn).closest("li").remove();
+}

--- a/src/main/resources/templates/flows/poll-vote/mobilePollResults.html
+++ b/src/main/resources/templates/flows/poll-vote/mobilePollResults.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{mopslayout :: html(name='Terminfindung und Abstimmung', headcontent=~{:: headcontent}, navigation=~{:: navigation}, bodycontent=~{:: bodycontent})}">
+<head>
+    <meta charset="utf-8">
+    <title>Terminfindung und Abstimmung</title>
+    <th:block th:fragment="headcontent">
+    </th:block>
+</head>
+<body>
+<header>
+    <nav class="navigation navigation-secondary" is="mops-navigation" th:fragment="navigation">
+        <ul th:replace="fragments/general.html :: navigationList"></ul>
+    </nav>
+</header>
+<main th:fragment="bodycontent">
+    <div class="container">
+        <div th:replace="fragments/pollVote.html :: results"></div>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/flows/poll-vote/mobilePollVote.html
+++ b/src/main/resources/templates/flows/poll-vote/mobilePollVote.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{mopslayout :: html(name='Terminfindung und Abstimmung', headcontent=~{:: headcontent}, navigation=~{:: navigation}, bodycontent=~{:: bodycontent})}">
+<head>
+    <meta charset="utf-8">
+    <title>Terminfindung und Abstimmung</title>
+    <th:block th:fragment="headcontent">
+    </th:block>
+</head>
+<body>
+<header>
+    <nav class="navigation navigation-secondary" is="mops-navigation" th:fragment="navigation">
+        <ul th:replace="fragments/general.html :: navigationList"></ul>
+    </nav>
+</header>
+<main th:fragment="bodycontent">
+    <div class="container">
+        <form th:replace="fragments/pollVote.html :: voteform"></form>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/flows/poll/mobilePollChoiceOptions.html
+++ b/src/main/resources/templates/flows/poll/mobilePollChoiceOptions.html
@@ -25,7 +25,7 @@
 <main th:fragment="bodycontent">
     <div class="container">
         <div th:replace="fragments/general.html :: pageHeading(process='Neue Abstimmung', page='Auswahlmöglichkeiten')"></div>
-        <form method="post" id="terminChoiceOptions">
+        <form th:action method="post" id="terminChoiceOptions">
             <div class="form-group">
                 <input class="form-control" type="date">
                 <button name="addOption" class="btn btn-primary" onclick="addChoiceOption()"><img th:src="@{icons/plus.svg}" width="30" height="30" class="d-inline-block align-top" alt=""></button>

--- a/src/main/resources/templates/flows/poll/mobilePollChoiceSettings.html
+++ b/src/main/resources/templates/flows/poll/mobilePollChoiceSettings.html
@@ -17,6 +17,15 @@
                     $('.collapse').collapse('hide');
                 }
             }
+            function showMutable(){
+                if( $("input[name=choice-mutable]").is(':checked') ){
+                    $("input[name=choice-addNew]").prop('disabled', false)
+                }
+                else{
+                    $("input[name=choice-addNew]").prop('checked', false);
+                    $("input[name=choice-addNew]").prop('disabled', true)
+                }
+            }
         </script>
     </th:block>
 </head>

--- a/src/main/resources/templates/flows/poll/mobilePollConfirmation.html
+++ b/src/main/resources/templates/flows/poll/mobilePollConfirmation.html
@@ -32,7 +32,7 @@
             <li>Löschung am (?)</li>
             <li>? Personen/Gruppen anzeigen ?</li>
         </ul>
-        <form method="post">
+        <form th:action method="post">
             <button type="submit" name="_eventId_publication"  class="btn btn-primary float-left mt-5">Zurück</button>
             <button type="submit" name="_eventId_submit"  class="btn btn-primary float-right mt-5">Erstellen</button>
         </form>

--- a/src/main/resources/templates/flows/scheduling/mobileSchedulingChoiceOptions.html
+++ b/src/main/resources/templates/flows/scheduling/mobileSchedulingChoiceOptions.html
@@ -7,13 +7,17 @@
     <th:block th:fragment="headcontent">
         <!-- Links, Skripts, Styles hier einfügen! -->
         <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
-        <script>
+        <script type="text/javascript" th:src="@{/choiceOptions.js}"></script>
+        <!--<script>
+            let count = 0;
+            $('#scheduleOptionCount').text('1');
+
             function addChoiceOption(){
                 $('#terminChoiceOptions .form-group').last().append(`<div class="form-group">
                 <input class="form-control" type="date">
-            </div>`)
+            </div>`);
             }
-        </script>
+        </script>-->
     </th:block>
 </head>
 <body>
@@ -22,17 +26,37 @@
         <ul th:replace="fragments/general.html :: navigationList(newTerminActive=true)"></ul>
     </nav>
 </header>
-<main th:fragment="bodycontent">
-    <div class="container">
+<main th:fragment="bodycontent" class="d-flex flex-column" style="min-height: 100vh">
+    <div class="container flex-fill">
         <div th:replace="fragments/general.html :: pageHeading(process='Neue Terminfindung', page='Auswahlmöglichkeiten')"></div>
-        <form method="post" id="terminChoiceOptions">
+        <form th:action method="post" id="terminChoiceOptions">
             <div class="form-group">
-                <input class="form-control" type="date">
-                <button type="button" name="addOption" class="btn btn-primary" onclick="addChoiceOption()"><img th:src="@{icons/plus.svg}" width="30" height="30" class="d-inline-block align-top" alt=""></button>
+                <!--<div>Termin <span id="scheduleOptionCount">x</span>:</div>-->
+                <ol id="scheduleOptionList">
+                    <li>
+                        <div class="form-group row">
+                            <input name="dateOption" class="form-control col ml-5" type="date">
+                            <input class="form-control col ml-5" type="time" value="12:00">
+                            <div class="col-1">
+                                <button style="width: 37px; height: 37px" type="button" name="removeOption" class="btn btn-danger" onclick="removeChoiceOption(this)">-</button>
+                            </div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="form-group row">
+                            <input name="dateOption" class="form-control col ml-5" type="date">
+                            <input class="form-control col ml-5" type="time" value="12:00">
+                            <div class="col-1">
+                                <button style="width: 37px; height: 37px" type="button" name="removeOption" class="btn btn-danger" onclick="removeChoiceOption(this)">-</button>
+                            </div>
+                        </div>
+                    </li>
+                </ol>
+                <button type="button" name="addOption" class="btn btn-primary" onclick="addChoiceOption()">+</button>
             </div>
 
-            <button type="submit" name="_eventId_choicesettings"  class="btn btn-primary float-left">Zurück</button>
-            <button type="submit" name="_eventId_publication"  class="btn btn-primary float-right">Weiter</button>
+            <button type="submit" name="_eventId_choicesettings"  class="btn btn-primary float-left mt-5">Zurück</button>
+            <button type="submit" name="_eventId_publication"  class="btn btn-primary float-right mt-5">Weiter</button>
         </form>
     </div>
 </main>

--- a/src/main/resources/templates/flows/scheduling/mobileSchedulingChoiceSettings.html
+++ b/src/main/resources/templates/flows/scheduling/mobileSchedulingChoiceSettings.html
@@ -11,10 +11,19 @@
         <script>
             function showPriorities(){
                 if( $("input[name=choice-amount]:checked").val() === "multiple-choice" ){
-                    $('.collapse').collapse('show');
+                    $('#collapsePriorities').collapse('show');
                 }
                 else{
-                    $('.collapse').collapse('hide');
+                    $('#collapsePriorities').collapse('hide');
+                }
+            }
+            function showMutable(){
+                if( $("input[name=choice-mutable]").is(':checked') ){
+                    $("input[name=choice-addNew]").prop('disabled', false)
+                }
+                else{
+                    $("input[name=choice-addNew]").prop('checked', false);
+                    $("input[name=choice-addNew]").prop('disabled', true)
                 }
             }
         </script>

--- a/src/main/resources/templates/flows/scheduling/mobileSchedulingConfirmation.html
+++ b/src/main/resources/templates/flows/scheduling/mobileSchedulingConfirmation.html
@@ -31,7 +31,7 @@
             <li>Löschung am (?)</li>
             <li>? Personen/Gruppen anzeigen ?</li>
         </ul>
-        <form method="post">
+        <form th:action  method="post">
             <button type="submit" name="_eventId_publication"  class="btn btn-primary float-left mt-5">Zurück</button>
             <button type="submit" name="_eventId_submit"  class="btn btn-primary float-right mt-5">Erstellen</button>
         </form>

--- a/src/main/resources/templates/fragments/accessSettings.html
+++ b/src/main/resources/templates/fragments/accessSettings.html
@@ -8,7 +8,7 @@
     </th:block>
 </head>
 <body>
-    <form method="post" th:fragment="form">
+    <form th:action method="post" th:fragment="form">
         <div class="form-group">
             <label>Start</label>
             <div class="row">

--- a/src/main/resources/templates/fragments/choiceSettings.html
+++ b/src/main/resources/templates/fragments/choiceSettings.html
@@ -8,7 +8,7 @@
     </th:block>
 </head>
 <body>
-    <form method="post" th:fragment="form">
+    <form th:action method="post" th:fragment="form">
         <div class="choice-amount">
             <label>Anzahl Auswahlmöglichkeiten</label>
             <div class="form-check">
@@ -38,8 +38,15 @@
                 </div>
             </div>
         </div>
-        <div class="form-check pt-5">
-            <input class="form-check-input" type="checkbox">
+
+        <div class="form-check">
+            <input class="form-check-input" name="choice-mutable" type="checkbox" onchange="showMutable()">
+            <label class="form-check-label">
+                Stimme im nachhinein editierbar
+            </label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" name="choice-addNew" type="checkbox" disabled>
             <label class="form-check-label">
                 Möglichkeiten ergänzbar
             </label>

--- a/src/main/resources/templates/fragments/nameSettings.html
+++ b/src/main/resources/templates/fragments/nameSettings.html
@@ -8,7 +8,7 @@
     </th:block>
 </head>
 <body>
-    <form method="post" class="needs-validation" novalidate th:fragment="form">
+    <form th:action method="post" class="needs-validation" novalidate th:fragment="form">
         <div class="form-group">
             <label>Titel</label>
             <input th:if="${terminfindung}" class="form-control" id="termin-title" placeholder="Neue Terminfindung" required>

--- a/src/main/resources/templates/fragments/pollVote.html
+++ b/src/main/resources/templates/fragments/pollVote.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{mopslayout :: html(name='Terminfindung und Abstimmung', headcontent=~{:: headcontent}, navigation=~{:: navigation}, bodycontent=~{:: bodycontent})}">
+<head>
+    <meta charset="utf-8">
+    <title>Terminfindung und Abstimmung</title>
+    <th:block th:fragment="headcontent">
+    </th:block>
+</head>
+<body>
+<form th:action method="post" th:fragment="voteform">
+    <div class="choice-amount">
+        <label>Anzahl Auswahlmöglichkeiten</label>
+        <div class="form-check">
+            <input class="form-check-input" name="choice-amount" type="radio" value="single-choice" onchange="showPriorities()" checked>
+            <label class="form-check-label">
+                Single Choice
+            </label>
+        </div>
+    </div>
+    <button type="submit" name="_eventId_home"  class="btn btn-primary float-left mt-5">Zurück</button>
+    <button type="submit" name="_eventId_results" class="btn btn-primary float-right mt-5">Abstimmen</button>
+</form>
+<div th:fragment="results">
+    <ul>
+        <li>3 für A</li>
+        <li>3 für B</li>
+        <li>3 für C</li>
+    </ul>
+    <form th:action method="post">
+        <button type="submit" name="_eventId_vote" class="btn btn-primary float-left mt-5">Ändern</button>
+        <button type="submit" name="_eventId_home" class="btn btn-primary float-left mt-5">Fertig</button>
+    </form>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/publicationSettings.html
+++ b/src/main/resources/templates/fragments/publicationSettings.html
@@ -8,7 +8,7 @@
     </th:block>
 </head>
 <body>
-    <form method="post" th:fragment="form">
+    <form th:action method="post" th:fragment="form">
         <div class="form-group">
             <label>Dein Link</label>
             <input type="text" class="form-control" id="termin-link" value="LINK" readonly>


### PR DESCRIPTION
Um Formulare abzusichern, einfach th:action im <form>-Tag benutzen, Thymeleaf fügt das versteckte Input-Feld automatisch hinzu.

Ohne th:action wird folgendes Input-Feld benötigt:
`<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />`