### PR TITLE
Model-Binding und Validierung mit Web Flow beispielhaft implementiert

### DIFF
--- a/src/main/java/mops/application/services/DatePollBuilderAndView.java
+++ b/src/main/java/mops/application/services/DatePollBuilderAndView.java
@@ -4,16 +4,16 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import mops.controllers.dtos.DatePollOptionDto;
 import mops.domain.models.Validation;
-import mops.domain.models.datepoll.DatePoll;
 import mops.domain.models.datepoll.DatePollBuilder;
 import mops.domain.models.datepoll.DatePollConfig;
 import mops.domain.models.datepoll.DatePollMetaInf;
 
+import java.io.Serializable;
 import java.util.List;
 
 @RequiredArgsConstructor
 @Data
-public class DatePollBuilderAndView {
+public class DatePollBuilderAndView implements Serializable {
 
     private final DatePollBuilder builder;
     private DatePollConfig config;
@@ -21,13 +21,13 @@ public class DatePollBuilderAndView {
     private List<DatePollOptionDto> datePollOptionDtos;
     private Validation validation;
 
-    /**
+    /*
      * Methode dient zur erstellung des DatePoll Objektes.
      *
      * @return DatePoll Objekt, welches den derzeitigen Status des Builders implementiert
      */
-    public DatePoll startBuildingDatePoll() {
+    /*public DatePoll startBuildingDatePoll() {
         return this.builder.build();
-    }
+    }*/
 
 }

--- a/src/main/java/mops/application/services/DatePollCreateService.java
+++ b/src/main/java/mops/application/services/DatePollCreateService.java
@@ -2,13 +2,11 @@ package mops.application.services;
 
 import lombok.NoArgsConstructor;
 import mops.controllers.dtos.DatePollOptionDto;
-import mops.domain.models.datepoll.DatePoll;
-import mops.domain.models.datepoll.DatePollBuilder;
-import mops.domain.models.datepoll.DatePollConfig;
-import mops.domain.models.datepoll.DatePollMetaInf;
+import mops.domain.models.datepoll.*;
 import mops.domain.models.user.UserId;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -60,29 +58,29 @@ public class DatePollCreateService {
         datePollBuilderAndView.setMetaInf(datePollMetaInf);
     }
 
-    /**
+    /*
      * Vierte Instanz zur Erstellung der Terminfindung.
      * Liste der Datum-Eintraege an denen der Termin stattfinden kann.
      *
      * @param datePollBuilderAndView Das Lombok-Builder Objekt aus initializeDatePoll.
      * @param datePollOptionDtos     Alle Datums-Eintraege des User creator.
      */
-    public void initDatePollOptionList(
+    /*public void initDatePollOptionList(
             final DatePollBuilderAndView datePollBuilderAndView, final List<DatePollOptionDto> datePollOptionDtos) {
         final DatePollBuilder builder = datePollBuilderAndView.getBuilder();
         datePollBuilderAndView.setValidation(
                 builder.datePollOptions(datePollOptionDtos).getValidationState()
         );
         datePollBuilderAndView.setDatePollOptionDtos(datePollOptionDtos);
-    }
+    }*/
 
-    /**
+    /*
      * Handelt es sich um eine oeffentliche oder geschlossene Abstimmung?
      *
      * @param datePollBuilderAndView
      * @param openDatePoll
      */
-    public void openOrClosedPoll(final DatePollBuilderAndView datePollBuilderAndView, final boolean openDatePoll) {
+    /*public void openOrClosedPoll(final DatePollBuilderAndView datePollBuilderAndView, final boolean openDatePoll) {
         final DatePollBuilder builder = datePollBuilderAndView.getBuilder();
         final DatePollConfig oldConfig = datePollBuilderAndView.getConfig();
         final DatePollConfig newConfig = oldConfig.withOpenForOwnEntries(openDatePoll);
@@ -90,16 +88,16 @@ public class DatePollCreateService {
                 builder.datePollConfig(newConfig).getValidationState()
         );
         datePollBuilderAndView.setConfig(newConfig);
-    }
+    }*/
 
-    /**
+    /*
      * Fuenfte Instanz zur Erstellung der Terminfindung.
      * Angabe ob es sich um ein "single" oder "multiple" Choice Terminfindungs-Objekt handelt.
      *
      * @param datePollBuilderAndView Das Lombok-Builder Objekt aus initializeDatePoll.
      * @param singleChoicePoll       Hat der User nur eine Wahlmoeglichkeit (true) oder mehrere (false).
      */
-    public void setDatePollChoiceType(
+    /*public void setDatePollChoiceType(
             final DatePollBuilderAndView datePollBuilderAndView, final boolean singleChoicePoll) {
         final DatePollBuilder builder = datePollBuilderAndView.getBuilder();
         final DatePollConfig oldConfig = datePollBuilderAndView.getConfig();
@@ -108,16 +106,17 @@ public class DatePollCreateService {
                 builder.datePollConfig(newConfig).getValidationState()
         );
         datePollBuilderAndView.setConfig(newConfig);
-    }
+    }*/
 
-    /**
+    /*
      * Fuenfte Instanz zur Erstellung der Terminfindung.
      * Angabe ob es priorisierte Auswahlmoeglichkeiten geben soll.
      *
      * @param datePollBuilderAndView Das Lombok-Builder Objekt aus initializeDatePoll.
      * @param priority               Prioritaet an (true) oder aus (false).
      */
-    public void setDatePollChoicePriority(final DatePollBuilderAndView datePollBuilderAndView, final boolean priority) {
+    /*public void setDatePollChoicePriority(final DatePollBuilderAndView datePollBuilderAndView,
+                                                final boolean priority) {
         final DatePollBuilder builder = datePollBuilderAndView.getBuilder();
         final DatePollConfig oldConfig = datePollBuilderAndView.getConfig();
         final DatePollConfig newConfig = oldConfig.withPriorityChoice(priority);
@@ -125,16 +124,16 @@ public class DatePollCreateService {
                 builder.datePollConfig(newConfig).getValidationState()
         );
         datePollBuilderAndView.setConfig(newConfig);
-    }
+    }*/
 
-    /**
+    /*
      * Sechste Instanz zur Erstellung der Terminfindung.
      * Angabe ob die Terminfindung anonym (true) oder öffentlich (false) stattfinden soll.
      *
      * @param datePollBuilderAndView Das Lombok-Builder Objekt aus initializeDatePoll.
      * @param anonymous              Anonym (true) oder öffentlich (false).
      */
-    public void setDatePollVisibility(final DatePollBuilderAndView datePollBuilderAndView, final boolean anonymous) {
+    /*public void setDatePollVisibility(final DatePollBuilderAndView datePollBuilderAndView, final boolean anonymous) {
         final DatePollBuilder builder = datePollBuilderAndView.getBuilder();
         final DatePollConfig oldConfig = datePollBuilderAndView.getConfig();
         final DatePollConfig newConfig = oldConfig.withAnonymous(anonymous);
@@ -142,5 +141,13 @@ public class DatePollCreateService {
                 builder.datePollConfig(newConfig).getValidationState()
         );
         datePollBuilderAndView.setConfig(newConfig);
+    }*/
+
+    /**
+     * dsfasf.
+     * @return afdsfdsafafdsf
+     */
+    public DatePoll newDatePoll() {
+        return new DatePoll();
     }
 }

--- a/src/main/java/mops/application/services/DatePollPublicationService.java
+++ b/src/main/java/mops/application/services/DatePollPublicationService.java
@@ -21,17 +21,17 @@ public class DatePollPublicationService {
     private transient DatePollRepository datePollRepository;
     private transient GroupRepository groupRepository;
 
-    /**
+    /*
      * Beendet den Erstellungsprozess und speichert die erstellte Terminfindung.
      *
      * @param datePollBuilderAndView Um an den datePollConfigDto
      * @return DatePoll Objekt.
      */
-    public DatePoll publishDatePoll(final DatePollBuilderAndView datePollBuilderAndView) {
+    /*public DatePoll publishDatePoll(final DatePollBuilderAndView datePollBuilderAndView) {
         final DatePoll created = datePollBuilderAndView.startBuildingDatePoll();
         datePollRepository.save(created);
         return created;
-    }
+    }*/
 
     /**
      * Wenn der Link noch nicht vergeben wurde wird dieser als Veröffentlichungslink gesetzt.

--- a/src/main/java/mops/controllers/DashboardController.java
+++ b/src/main/java/mops/controllers/DashboardController.java
@@ -1,7 +1,12 @@
 package mops.controllers;
 
+import mops.domain.models.user.UserId;
+import org.keycloak.KeycloakPrincipal;
+import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.annotation.security.RolesAllowed;
 
@@ -13,13 +18,19 @@ import javax.annotation.security.RolesAllowed;
 @SuppressWarnings("PMD.AtLeastOneConstructor")
 public class DashboardController {
 
+    private UserId createUserIdFromPrincipal(KeycloakAuthenticationToken token) {
+        KeycloakPrincipal principal = (KeycloakPrincipal) token.getPrincipal();
+        return new UserId(principal.getKeycloakSecurityContext().getIdToken().getEmail());
+    }
+
     /**
      * GetMapping für das Dashboard.
      * @return Dashboard-Template.
      */
     @RolesAllowed({"ROLE_orga", "ROLE_studentin"})
     @GetMapping("/")
-    public String returnDashboard() {
+    public String returnDashboard(KeycloakAuthenticationToken token, Model model) {
+        model.addAttribute("userId", createUserIdFromPrincipal(token));
         return "mobile-dashboard";
     }
 }

--- a/src/main/java/mops/domain/models/Validation.java
+++ b/src/main/java/mops/domain/models/Validation.java
@@ -2,9 +2,10 @@ package mops.domain.models;
 
 import mops.controllers.dtos.InputFieldNames;
 
+import java.io.Serializable;
 import java.util.EnumMap;
 
-public class Validation {
+public class Validation implements Serializable {
     private EnumMap<InputFieldNames, String> errorMessages;
 
     private Validation() {

--- a/src/main/java/mops/domain/models/datepoll/DatePoll.java
+++ b/src/main/java/mops/domain/models/datepoll/DatePoll.java
@@ -1,16 +1,19 @@
 package mops.domain.models.datepoll;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import mops.domain.models.pollstatus.PollStatus;
 import mops.domain.models.user.User;
 import mops.domain.models.user.UserId;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
-public final class DatePoll {
+@Setter
+@NoArgsConstructor
+public final class DatePoll implements Serializable {
 
 
     /**
@@ -41,7 +44,7 @@ public final class DatePoll {
     /**
      * Link fuer den DatePoll.
      */
-    private final DatePollLink datePollLink;
+    private DatePollLink datePollLink;
 
     public static DatePollBuilder builder() {
         return new DatePollBuilder();

--- a/src/main/java/mops/domain/models/datepoll/DatePollBuilder.java
+++ b/src/main/java/mops/domain/models/datepoll/DatePollBuilder.java
@@ -5,8 +5,8 @@ import mops.controllers.dtos.DatePollOptionDto;
 import mops.domain.models.ValidateAble;
 import mops.domain.models.Validation;
 import mops.domain.models.user.UserId;
-import org.hibernate.validator.internal.util.stereotypes.Immutable;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-public class DatePollBuilder {
+public class DatePollBuilder implements Serializable {
 
     public static final String COULD_NOT_CREATE = "The Builder contains errors and DatePoll could not be created";
 
@@ -97,13 +97,13 @@ public class DatePollBuilder {
         return this;
     }
 
-    /**
+    /*
      * Fügt alle validierte Otions der Vorschlägeliste hinzu.
      *
      * @param datePollOptionsDtos Vorschläge die zu dieser Terminfindung hinzugefügt werden sollen.
      * @return Referenz auf diesen DatePollBuilder.
      */
-    public DatePollBuilder datePollOptions(List<DatePollOptionDto> datePollOptionsDtos) {
+    /*public DatePollBuilder datePollOptions(List<DatePollOptionDto> datePollOptionsDtos) {
         this.datePollOptionsTarget.addAll(validateAllAndGetCorrect(
                 datePollOptionsDtos.stream()
                         .map(dto -> new DatePollOption(dto.getStartDate(), dto.getEndDate()))
@@ -113,7 +113,7 @@ public class DatePollBuilder {
             validatedFields.add(DatePollFields.DATE_POLL_OPTIONS);
         }
         return this;
-    }
+    }*/
 
     /**
      * Fügt alle validierte User der Teilnehmerliste hinzu.
@@ -142,21 +142,22 @@ public class DatePollBuilder {
         return this;
     }
 
-    /**
+    /*
      * Baut das DatePoll Objekt, wenn alle Konstruktionssteps mind. 1 mal erfolgreich waren.
      *
      * @return Ein DatePoll Objekt in einem validen State.
      */
-    public DatePoll build() {
+    /*public DatePoll build() {
         if (validationState.hasNoErrors() && EnumSet.allOf(DatePollFields.class).equals(validatedFields)) {
             return new DatePoll(
                     new PollRecordAndStatus(),
-                    datePollMetaInfTarget, creatorTarget, datePollConfigTarget, datePollOptionsTarget, participantsTarget, datePollLinkTarget
+                    datePollMetaInfTarget, creatorTarget, datePollConfigTarget, datePollOptionsTarget,
+                    participantsTarget, datePollLinkTarget
             );
         } else {
             throw new IllegalStateException(COULD_NOT_CREATE);
         }
-    }
+    }*/
 
     private enum DatePollFields {
         DATE_POLL_CONFIG, DATE_POLL_LINK, DATE_POLL_META_INF, DATE_POLL_OPTIONS, CREATOR, PARTICIPANTS

--- a/src/main/java/mops/domain/models/datepoll/DatePollConfig.java
+++ b/src/main/java/mops/domain/models/datepoll/DatePollConfig.java
@@ -1,15 +1,18 @@
 package mops.domain.models.datepoll;
 
 import lombok.AllArgsConstructor;
-import lombok.Value;
-import lombok.With;
+import lombok.Getter;
+import lombok.Setter;
 import mops.domain.models.ValidateAble;
 import mops.domain.models.Validation;
+import org.springframework.binding.validation.ValidationContext;
 
-@Value
-@With
+import java.io.Serializable;
+
+@Getter
+@Setter
 @AllArgsConstructor
-public class DatePollConfig implements ValidateAble {
+public class DatePollConfig implements ValidateAble, Serializable {
 
     /**
      * true: User kann selbst Termine zur Abstimmung hinzufügen.
@@ -55,5 +58,15 @@ public class DatePollConfig implements ValidateAble {
     @Override
     public Validation validate() {
         return Validation.noErrors();
+    }
+
+
+    // TODO: Sinnvolle Beschränkungen setzen, wenn verschiedene Optionen nicht zueinander passen o.Ä.
+
+    /**
+     * Wird vom Builder oder von Web Flow für den State „mobileSchedulingChoiceSettings“ aufgerufen.
+     * @param context Der ValidationContext wird vom Builder oder Web Flow übergeben und ausgewertet.
+     */
+    public void validateMobileSchedulingChoiceSettings(ValidationContext context) {
     }
 }

--- a/src/main/java/mops/domain/models/datepoll/DatePollMetaInf.java
+++ b/src/main/java/mops/domain/models/datepoll/DatePollMetaInf.java
@@ -1,13 +1,31 @@
 package mops.domain.models.datepoll;
 
-import lombok.Value;
+import lombok.Getter;
+import lombok.Setter;
 import mops.domain.models.ValidateAble;
 import mops.domain.models.Validation;
+import mops.domain.models.datepoll.old.DatePollDescription;
+import mops.domain.models.datepoll.old.DatePollLifeCycle;
+import mops.domain.models.datepoll.old.DatePollLocation;
+import org.springframework.binding.message.MessageBuilder;
+import org.springframework.binding.message.MessageContext;
+import org.springframework.binding.message.MessageResolver;
+import org.springframework.binding.validation.ValidationContext;
 
-@Value
-public class DatePollMetaInf implements ValidateAble {
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
-    private String title;
+@Getter
+@Setter
+public class DatePollMetaInf implements ValidateAble, Serializable {
+
+    private String title = "";
+    private String description = "";
+    private String location = "";
+    private LocalDateTime startDate = LocalDateTime.now();
+    private LocalDateTime endDate = LocalDateTime.now();
+
     private DatePollDescription datePollDescription;
     private DatePollLocation datePollLocation;
     private DatePollLifeCycle datePollLifeCycle;
@@ -22,5 +40,88 @@ public class DatePollMetaInf implements ValidateAble {
         validation.appendValidation(datePollDescription.validate());
         validation.appendValidation(datePollLifeCycle.validate());
         return validation;
+    }
+
+    /**
+     * Wird vom Builder oder von Web Flow für den State „mobileSchedulingNameSettings“
+     * aufgerufen und aggregiert alle Fehlermeldungen aus den einzelnen Validierungsmethoden.
+     * @param context Der ValidationContext wird vom Builder oder Web Flow übergeben und ausgewertet.
+     */
+    public void validateMobileSchedulingNameSettings(ValidationContext context) {
+        MessageContext messageContext = context.getMessageContext();
+        validateTitle()
+                .ifPresent(messageContext::addMessage);
+        validateDescription()
+                .ifPresent(messageContext::addMessage);
+        validateLocation()
+                .ifPresent(messageContext::addMessage);
+
+    }
+
+    /**
+     * Wird vom Builder oder von Web Flow für den State „mobileSchedulingAccessSettings“
+     * aufgerufen und aggregiert alle Fehlermeldungen aus den einzelnen Validierungsmethoden.
+     * @param context Der ValidationContext wird vom Builder oder Web Flow übergeben und ausgewertet.
+     */
+    public void validateMobileSchedulingAccessSettings(ValidationContext context) {
+        MessageContext messageContext = context.getMessageContext();
+        validateLifecycle().ifPresent(messageContext::addMessage);
+    }
+
+    // TODO: Sinnvolle Beschränkungen und Validierungen setzen, diese Methoden sind nur als Beispiel gedacht.
+
+    private Optional<MessageResolver> validateTitle() {
+        if (title.length() > 4) {
+            return Optional.of(
+                    new MessageBuilder()
+                            .error()
+                            .source("title")
+                            .defaultText("Titel muss kürzer als 5 Zeichen sein")
+                            .build());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<MessageResolver> validateDescription() {
+        if (description.length() > 200) {
+            return Optional.of(
+                    new MessageBuilder()
+                            .error()
+                            .source("description")
+                            .defaultText("Beschreibung muss kürzer als 200 Zeichen sein").build());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<MessageResolver> validateLocation() {
+        if (location.length() > 100) {
+            return Optional.of(
+                    new MessageBuilder()
+                            .error()
+                            .source("location")
+                            .defaultText("Ortsangabe muss kürzer als 100 Zeichen sein").build());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<MessageResolver> validateLifecycle() {
+        Optional<MessageResolver> messageResolver = Optional.empty();
+        if (startDate.isAfter(endDate)) {
+            messageResolver = Optional.of(
+                    new MessageBuilder()
+                            .error()
+                            .source("lifecycle")
+                            .defaultText("Das Startdatum muss von dem Enddatum liegen")
+                            .build());
+        }
+        if (endDate.isBefore(LocalDateTime.now())) {
+            messageResolver = Optional.of(
+                    new MessageBuilder()
+                            .error()
+                            .source("lifecycle")
+                            .defaultText("Das Enddatum muss in der Zukunft liegen")
+                            .build());
+        }
+        return messageResolver;
     }
 }

--- a/src/main/java/mops/domain/models/datepoll/DatePollOption.java
+++ b/src/main/java/mops/domain/models/datepoll/DatePollOption.java
@@ -1,23 +1,57 @@
 package mops.domain.models.datepoll;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import mops.domain.models.ValidateAble;
 import mops.domain.models.Validation;
+import org.springframework.binding.message.MessageBuilder;
+import org.springframework.binding.message.MessageContext;
+import org.springframework.binding.message.MessageResolver;
+import org.springframework.binding.validation.ValidationContext;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
+@Getter
+@Setter
+@NoArgsConstructor
 class DatePollOption implements ValidateAble {
 
-    private final DatePollLifeCycle dateOptionDuration;
+    //private final DatePollLifeCycle dateOptionDuration;
     //Anzahl der Stimmen fuer diesen Termin.
     private int votes;
 
-    DatePollOption(final LocalDateTime startDate, final LocalDateTime endDate) {
+    /*DatePollOption(final LocalDateTime startDate, final LocalDateTime endDate) {
         this.dateOptionDuration = new DatePollLifeCycle(startDate, endDate);
-    }
+    }*/
 
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
 
     @Override
     public Validation validate() {
-        return dateOptionDuration.validate();
+        //return dateOptionDuration.validate();
+        return Validation.noErrors();
+    }
+
+    public void validateDatePollOption(ValidationContext context) {
+        MessageContext messageContext = context.getMessageContext();
+        if (startDate.isAfter(endDate)) {
+            messageContext.addMessage(
+                    new MessageBuilder()
+                            .error()
+                            .source("lifecycle")
+                            .defaultText("Das Startdatum muss von dem Enddatum liegen")
+                            .build());
+        }
+        if (endDate.isBefore(LocalDateTime.now())) {
+            messageContext.addMessage(
+                    new MessageBuilder()
+                            .error()
+                            .source("lifecycle")
+                            .defaultText("Das Enddatum muss in der Zukunft liegen")
+                            .build());
+        }
     }
 }

--- a/src/main/java/mops/domain/models/datepoll/old/DatePollDescription.java
+++ b/src/main/java/mops/domain/models/datepoll/old/DatePollDescription.java
@@ -1,4 +1,4 @@
-package mops.domain.models.datepoll;
+package mops.domain.models.datepoll.old;
 
 
 import lombok.Value;
@@ -6,8 +6,10 @@ import mops.controllers.dtos.InputFieldNames;
 import mops.domain.models.ValidateAble;
 import mops.domain.models.Validation;
 
+import java.io.Serializable;
+
 @Value
-public class DatePollDescription implements ValidateAble {
+public class DatePollDescription implements ValidateAble, Serializable {
 
     private String description;
 

--- a/src/main/java/mops/domain/models/datepoll/old/DatePollLifeCycle.java
+++ b/src/main/java/mops/domain/models/datepoll/old/DatePollLifeCycle.java
@@ -1,14 +1,15 @@
-package mops.domain.models.datepoll;
+package mops.domain.models.datepoll.old;
 
 import lombok.Value;
 import mops.controllers.dtos.InputFieldNames;
 import mops.domain.models.ValidateAble;
 import mops.domain.models.Validation;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Value
-public class DatePollLifeCycle implements ValidateAble {
+public class DatePollLifeCycle implements ValidateAble, Serializable {
     private final LocalDateTime startDate;
     private LocalDateTime endDate;
 

--- a/src/main/java/mops/domain/models/datepoll/old/DatePollLocation.java
+++ b/src/main/java/mops/domain/models/datepoll/old/DatePollLocation.java
@@ -1,10 +1,12 @@
-package mops.domain.models.datepoll;
+package mops.domain.models.datepoll.old;
 
 import mops.controllers.dtos.InputFieldNames;
 import mops.domain.models.ValidateAble;
 import mops.domain.models.Validation;
 
-public class DatePollLocation implements ValidateAble {
+import java.io.Serializable;
+
+public class DatePollLocation implements ValidateAble, Serializable {
     //Shall we define standard rules for description / location strings?
     private String location;
     //Do we realy need longitude and latitude attributes for a location?

--- a/src/main/java/mops/domain/models/user/UserId.java
+++ b/src/main/java/mops/domain/models/user/UserId.java
@@ -1,9 +1,22 @@
 package mops.domain.models.user;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import mops.domain.models.ValidateAble;
 import mops.domain.models.Validation;
 
-public class UserId implements ValidateAble {
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+@AllArgsConstructor
+@Getter
+public class UserId implements ValidateAble, Serializable {
+
+    private static final long serialVersionUID = 1984021897420418247L;
+
+    private String userId;
 
     /**
      * ...

--- a/src/main/java/mops/utils/BootstrapValidInvalid.java
+++ b/src/main/java/mops/utils/BootstrapValidInvalid.java
@@ -1,0 +1,31 @@
+package mops.utils;
+
+public class BootstrapValidInvalid {
+
+    /**
+     * Die Methode weist einem HTML-Input-Tag (k)eine Bootstrap-Klasse zu, falls das Eingabefeld gültig oder ungültig
+     * ist oder noch gar nichts eingegeben wurde.
+     *
+     * Verwendung in Thymeleaf:
+     * th:classappend="${T(mops.helpers.BootstrapValidInvalid)
+     *                   .getClass(#fields.hasErrors('title'), #fields.hasAnyErrors())}"
+     *
+     * @param fieldHasErrors muss im Template mit der Methode #fields.hasErrors('<fieldname>') ermittelt werden
+     * @param formHasErrors muss im Template mit der Methode #fields.hasAnyErrors() ermittelt werden
+     * @return gibt entweder „is-invalid“, „is-valid“ oder einen leeren String zurück, sodass das entsprechende
+     *         Feld farblich passend markiert wird
+     */
+
+    public static String getClass(boolean fieldHasErrors, boolean formHasErrors) {
+        // Feld ist ungültig, dann ist es einfach
+        if (fieldHasErrors) {
+            return "is-invalid";
+        } else if (formHasErrors) {
+            // Falls andere Felder Fehler enthalten, muss das Formular geprüft worden sein
+            // Ergo wird das Feld grün markiert.
+            return "is-valid";
+        }
+        // Ansonsten wurde das Formular noch nicht geprüft, dann soll das Feld auch nicht markiert werden.
+        return "";
+    }
+}

--- a/src/main/resources/flows/scheduling/scheduling-flow.xml
+++ b/src/main/resources/flows/scheduling/scheduling-flow.xml
@@ -6,17 +6,50 @@
 
     <secured attributes="ROLE_orga, ROLE_studentin" match="any" />
 
-    <view-state id="mobileSchedulingNameSettings" view="/flows/scheduling/mobileSchedulingNameSettings">
+    <input name="userId" type="mops.domain.models.user.UserId" required="true" />
+
+    <on-start>
+        <evaluate expression="datePollCreateService.newDatePoll()" result="flowScope.datePoll"/>
+        <evaluate expression="new mops.domain.models.datepoll.DatePollMetaInf()" result="flowScope.datePollMetaInf"/>
+        <evaluate expression="new mops.domain.models.datepoll.DatePollConfig()" result="flowScope.datePollConfig"/>
+    </on-start>
+
+    <view-state id="mobileSchedulingNameSettings" view="/flows/scheduling/mobileSchedulingNameSettings"
+                model="datePollMetaInf">
+
+        <binder>
+            <binding property="title"/>
+            <binding property="description"/>
+            <binding property="location"/>
+        </binder>
+
         <transition on="home" to="home"/>
         <transition on="access" to="mobileSchedulingAccessSettings"/>
     </view-state>
 
-    <view-state id="mobileSchedulingAccessSettings" view="/flows/scheduling/mobileSchedulingAccessSettings">
+    <view-state id="mobileSchedulingAccessSettings" view="/flows/scheduling/mobileSchedulingAccessSettings"
+                model="datePollMetaInf">
+
+        <binder>
+            <binding property="startDate"/>
+            <binding property="endDate"/>
+        </binder>
+
         <transition on="name" to="mobileSchedulingNameSettings"/>
         <transition on="choicesettings" to="mobileSchedulingChoiceSettings"/>
     </view-state>
 
-    <view-state id="mobileSchedulingChoiceSettings" view="flows/scheduling/mobileSchedulingChoiceSettings">
+    <view-state id="mobileSchedulingChoiceSettings" view="flows/scheduling/mobileSchedulingChoiceSettings"
+                model="datePollConfig">
+
+        <binder>
+            <binding property="priorityChoice"/>
+            <binding property="anonymous"/>
+            <binding property="openForOwnEntries"/>
+            <binding property="open"/>
+            <binding property="singleChoice"/>
+        </binder>
+
         <transition on="access" to="mobileSchedulingAccessSettings"/>
         <transition on="choiceoptions" to="mobileSchedulingChoiceOptions"/>
     </view-state>
@@ -36,6 +69,6 @@
         <transition on="submit" to="home"/>
     </view-state>
 
-    <end-state id="home" view="externalRedirect:contextRelative:/"/>
+    <end-state id="home" view="/"/>
 
 </flow>

--- a/src/main/resources/templates/fragments/general.html
+++ b/src/main/resources/templates/fragments/general.html
@@ -12,9 +12,13 @@
         <!--/*@thymesVar id="dashboardActive" type=""*/-->
         <li th:class="${dashboardActive}? active"><a href="/">Dashboard</a></li>
         <!--/*@thymesVar id="newTerminActive" type=""*/-->
-        <li th:class="${newTerminActive}? active"><a href="/scheduling">Terminfindung erstellen</a></li>
+        <li th:class="${newTerminActive}? active" th:if="${userId != null}">
+            <a th:href="@{/scheduling(userId=${userId.getUserId()})}">Terminfindung erstellen</a>
+        </li>
         <!--/*@thymesVar id="newAbstimmungActive" type=""*/-->
-        <li th:class="${newAbstimmungActive}? active"><a href="/poll">Abstimmung erstellen</a></li>
+        <li th:class="${newAbstimmungActive}? active">
+            <a href="/poll">Abstimmung erstellen</a>
+        </li>
         <li><a href="">Beitreten</a></li>
     </ul>
 

--- a/src/main/resources/templates/fragments/nameSettings.html
+++ b/src/main/resources/templates/fragments/nameSettings.html
@@ -8,26 +8,32 @@
     </th:block>
 </head>
 <body>
-    <form th:action method="post" class="needs-validation" novalidate th:fragment="form">
+    <form method="post" class="needs-validation" novalidate th:fragment="form"
+          th:object="${datePollMetaInf}" id="datePollMetaInf" th:action="${flowExecutionUrl}" >
+
         <div class="form-group">
-            <label>Titel</label>
-            <input th:if="${terminfindung}" class="form-control" id="termin-title" placeholder="Neue Terminfindung" required>
-            <input th:unless="${terminfindung}" class="form-control" id="poll-title" placeholder="Neue Abstimmung" required>
-            <div th:if="${terminfindung}" class="invalid-feedback">
-                Bitte gib einen Titel für die Terminfindung ein.
-            </div>
-            <div th:unless="${terminfindung}" class="invalid-feedback">
-                Bitte gib einen Titel für die Abstimmung ein.
-            </div>
+            <label for="title">Titel</label>
+            <input class="form-control" id="title" type="text" th:field="*{title}"
+                   th:classappend="${T(mops.utils.BootstrapValidInvalid).getClass(#fields.hasErrors('title'), #fields.hasAnyErrors())}"
+                   th:placeholder="${terminfindung} ? 'Neue Terminfindung' : 'Neue Abstimmung'">
+            <div class="invalid-feedback" th:errors="*{title}"></div>
         </div>
+
         <div class="form-group">
-            <label>Beschreibung (optional)</label>
-            <input class="form-control" id="termin-description" placeholder="Beschreibung">
+            <label for="description">Beschreibung (optional)</label>
+            <input class="form-control" id="description" type="text" th:field="*{description}"
+                   th:classappend="${T(mops.utils.BootstrapValidInvalid).getClass(#fields.hasErrors('description'), #fields.hasAnyErrors())}"
+                   placeholder="Beschreibung">
+            <div class="invalid-feedback" th:errors="*{description}"></div>
         </div>
+
         <!--/*@thymesVar id="terminfindung" type=""*/-->
         <div class="form-group" th:if="${terminfindung}">
-            <label>Ort (optional)</label>
-            <input class="form-control" id="termin-location" placeholder="Ort">
+            <label for="location">Ort (optional)</label>
+            <input class="form-control" id="location" type="text" th:field="*{location}"
+                   th:classappend="${T(mops.utils.BootstrapValidInvalid).getClass(#fields.hasErrors('location'), #fields.hasAnyErrors())}"
+                   placeholder="Ort">
+            <div class="invalid-feedback" th:errors="*{location}"></div>
         </div>
         <button type="submit" name="_eventId_access"  class="btn btn-primary float-right mt-5">Weiter</button>
         <button type="submit" name="_eventId_home"  class="btn btn-primary float-left mt-5">Zurück</button>

--- a/src/test/java/mops/DatePollCreateServiceTest.java
+++ b/src/test/java/mops/DatePollCreateServiceTest.java
@@ -5,6 +5,9 @@ import mops.application.services.DatePollCreateService;
 
 import mops.controllers.dtos.DatePollOptionDto;
 import mops.domain.models.datepoll.*;
+import mops.domain.models.datepoll.old.DatePollDescription;
+import mops.domain.models.datepoll.old.DatePollLifeCycle;
+import mops.domain.models.datepoll.old.DatePollLocation;
 import mops.domain.models.user.UserId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
PMD und Checkstyle habe ich mehr oder weniger ignoriert, außerdem habe ich das Modell für DatePoll abgewandelt, um es in Einklang mit den einzelnen View-States der Weboberfläche zu bringen.

Das vorige Pattern mit dem Builder habe ich, wo nötig, auskommentiert. Es ist weiterhin möglich und könnte auch sinnvoll sein, den Builder beizubehalten, für Webflow allerdings eher weniger bis gar nicht.

Anmerkung: Wir haben uns jetzt darauf geeinigt, in den master zu mergen, es muss aber noch viel gefixt und geändert werden. Für sich gesehen sind diese Commits Unsinn.