### PR TITLE
Bug in Validation: removeErrors(PollFields fieldTyp) funktioniert nicht

### DIFF
--- a/src/main/java/mops/domain/models/Validation.java
+++ b/src/main/java/mops/domain/models/Validation.java
@@ -43,7 +43,7 @@ public final class Validation {
         newValidation.errorMessages
                 .stream()
                 .filter(error -> error.isChildOf(fieldTyp))
-                .forEach(errorMessages::remove);
+                .forEach(newValidation.errorMessages::remove);
         return newValidation;
     }
 }


### PR DESCRIPTION
this.errorMessages wird entfernt statt newValidation.errorMessages. Ist behoben.