### PR TITLE
Alter datepollentries and save them

### DIFF
--- a/src/main/java/mops/domain/models/pollstatus/PollRecordAndStatus.java
+++ b/src/main/java/mops/domain/models/pollstatus/PollRecordAndStatus.java
@@ -29,6 +29,7 @@ public class PollRecordAndStatus {
     @Getter
     @Setter
     private LocalDateTime lastModified = LocalDateTime.now();
+    @Getter
     private transient Map<UserId, PollStatus> votingRecord = new ConcurrentHashMap<>();
     @Getter
     private transient boolean isTerminated;

--- a/src/main/java/mops/infrastructure/database/daos/PollStatusEnum.java
+++ b/src/main/java/mops/infrastructure/database/daos/PollStatusEnum.java
@@ -1,5 +1,5 @@
 package mops.infrastructure.database.daos;
 
 public enum PollStatusEnum {
-    OPEN, REOPEN, ONGOING, TERMINATED
+    OPEN, REOPENED, ONGOING, TERMINATED
 }

--- a/src/main/java/mops/infrastructure/database/daos/datepoll/DatePollStatusDao.java
+++ b/src/main/java/mops/infrastructure/database/daos/datepoll/DatePollStatusDao.java
@@ -1,5 +1,6 @@
 package mops.infrastructure.database.daos.datepoll;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import mops.infrastructure.database.daos.PollStatusEnum;
 import mops.infrastructure.database.daos.UserDao;
@@ -16,6 +17,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "datepollstatus")
 @NoArgsConstructor
+@AllArgsConstructor
 public class DatePollStatusDao {
     @EmbeddedId
     private DatePollStatusDaoKey id;

--- a/src/main/java/mops/infrastructure/database/daos/datepoll/DatePollStatusDaoKey.java
+++ b/src/main/java/mops/infrastructure/database/daos/datepoll/DatePollStatusDaoKey.java
@@ -1,5 +1,6 @@
 package mops.infrastructure.database.daos.datepoll;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import javax.persistence.Column;
@@ -10,10 +11,11 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class DatePollStatusDaoKey implements Serializable {
     public static final long serialVersionUID = 4140192L;
     @Column(name = "user_id")
-    private Long userId;
+    private String userId;
     @Column(name = "datepoll_link")
     private String datePollLink;
 }

--- a/src/main/java/mops/infrastructure/database/daos/translator/DaoOfModelUtil.java
+++ b/src/main/java/mops/infrastructure/database/daos/translator/DaoOfModelUtil.java
@@ -7,6 +7,7 @@ import mops.domain.models.datepoll.DatePollEntry;
 import mops.domain.models.datepoll.DatePollMetaInf;
 import mops.domain.models.group.Group;
 import mops.domain.models.pollstatus.PollRecordAndStatus;
+import mops.domain.models.pollstatus.PollStatus;
 import mops.domain.models.questionpoll.QuestionPoll;
 import mops.domain.models.questionpoll.QuestionPollConfig;
 import mops.domain.models.questionpoll.QuestionPollEntry;
@@ -14,6 +15,7 @@ import mops.domain.models.questionpoll.QuestionPollMetaInf;
 import mops.domain.models.user.UserId;
 import mops.infrastructure.database.daos.GroupDao;
 import mops.infrastructure.database.daos.PollRecordAndStatusDao;
+import mops.infrastructure.database.daos.PollStatusEnum;
 import mops.infrastructure.database.daos.TimespanDao;
 import mops.infrastructure.database.daos.UserDao;
 import mops.infrastructure.database.daos.datepoll.DatePollConfigDao;
@@ -195,6 +197,19 @@ public final class DaoOfModelUtil {
         return link.getLinkUUIDAsString();
     }
 
+    public static PollStatusEnum createPollStatusEnumDao(PollStatus currentStatus) {
+        final PollStatusEnum newStatus;
+        if (currentStatus == PollStatus.OPEN) {
+            newStatus = PollStatusEnum.OPEN;
+        } else if (currentStatus == PollStatus.REOPENED) {
+            newStatus = PollStatusEnum.REOPENED;
+        } else if (currentStatus == PollStatus.ONGOING) {
+            newStatus =  PollStatusEnum.ONGOING;
+        } else {
+            newStatus = PollStatusEnum.TERMINATED;
+        }
+        return newStatus;
+    }
     /**
      * Wird nie instanziiert da util klasse.
      */

--- a/src/main/java/mops/infrastructure/database/repositories/DatePollEntryRepositoryManager.java
+++ b/src/main/java/mops/infrastructure/database/repositories/DatePollEntryRepositoryManager.java
@@ -85,6 +85,14 @@ public class DatePollEntryRepositoryManager {
     }
 
     /**
+     * Gibt alle DatePollEntries zum zugehoerigen DatePoll zurueck.
+     * @param datePollDao Das DatePoll Objekt.
+     * @return Set<DatePollEntryDao> Die zugehoerigen Enries.
+     */
+    public Set<DatePollEntryDao> findAllByDatePollLink(DatePollDao datePollDao) {
+        return datePollEntryJpaRepository.findByDatePoll(datePollDao);
+    }
+    /**
      * Die Methode gibt alle "Yes" Votes eines Users fuer einen DatePoll zurueck.
      * @param userId zugehoeriger User.
      * @param datePoll zugehoeriger DatePoll.

--- a/src/main/java/mops/infrastructure/database/repositories/DatePollEntryRepositoryManager.java
+++ b/src/main/java/mops/infrastructure/database/repositories/DatePollEntryRepositoryManager.java
@@ -62,7 +62,7 @@ public class DatePollEntryRepositoryManager {
      * @param pollLink zugehoeriger DatePoll.
      * @param datePollEntry Vorschlag fuer den abgestimmt wird.
      */
-    public void userVotesForDatePollEntry(UserId userId, PollLink pollLink, DatePollEntry datePollEntry) {
+    void userVotesForDatePollEntry(UserId userId, PollLink pollLink, DatePollEntry datePollEntry) {
         final DatePollEntryDao targetDatePollEntryDao = loadDatePollEntryDao(pollLink, datePollEntry);
         final UserDao currentUserDao = userJpaRepository.getOne(userId.getId());
         targetDatePollEntryDao.getUserVotesFor().add(currentUserDao);
@@ -86,7 +86,7 @@ public class DatePollEntryRepositoryManager {
      * @param datePollDao Das DatePoll Objekt.
      * @return Set<DatePollEntryDao> Die zugehoerigen Enries.
      */
-    public Set<DatePollEntryDao> findAllByDatePollLink(DatePollDao datePollDao) {
+    Set<DatePollEntryDao> findAllDatePollEntriesByDatePollDao(DatePollDao datePollDao) {
         return datePollEntryJpaRepository.findByDatePoll(datePollDao);
     }
     /**

--- a/src/main/java/mops/infrastructure/database/repositories/DatePollEntryRepositoryManager.java
+++ b/src/main/java/mops/infrastructure/database/repositories/DatePollEntryRepositoryManager.java
@@ -46,10 +46,7 @@ public class DatePollEntryRepositoryManager {
      * @param datePollEntry Der zugehörige Terminvorschlag.
      * @return DatePollEntryDao Das DatePollEntryDao Objekt aus der Datenbank.
      */
-     public DatePollEntryDao findDatePollEntryDao(
-             PollLink pollLink,
-             DatePollEntry datePollEntry
-     ) {
+     public DatePollEntryDao loadDatePollEntryDao(PollLink pollLink, DatePollEntry datePollEntry) {
          final DatePollDao currentDatePollDao = datePollJpaRepository.
                  findDatePollDaoByLink(pollLink.getLinkUUIDAsString());
          final Timespan periodOfDatePollEntry = datePollEntry.getSuggestedPeriod();
@@ -66,7 +63,7 @@ public class DatePollEntryRepositoryManager {
      * @param datePollEntry Vorschlag fuer den abgestimmt wird.
      */
     public void userVotesForDatePollEntry(UserId userId, PollLink pollLink, DatePollEntry datePollEntry) {
-        final DatePollEntryDao targetDatePollEntryDao = findDatePollEntryDao(pollLink, datePollEntry);
+        final DatePollEntryDao targetDatePollEntryDao = loadDatePollEntryDao(pollLink, datePollEntry);
         final UserDao currentUserDao = userJpaRepository.getOne(userId.getId());
         targetDatePollEntryDao.getUserVotesFor().add(currentUserDao);
         currentUserDao.getDatePollEntrySet().add(targetDatePollEntryDao);
@@ -80,7 +77,7 @@ public class DatePollEntryRepositoryManager {
      * @return votes Die Anzahl an "yes" Stimmen fuer die jeweilige Abstimmung.
      */
     public Long getVotesForDatePollEntry(PollLink pollLink, DatePollEntry datePollEntry) {
-        final DatePollEntryDao datePollEntryDao = findDatePollEntryDao(pollLink, datePollEntry);
+        final DatePollEntryDao datePollEntryDao = loadDatePollEntryDao(pollLink, datePollEntry);
         return userJpaRepository.countByDatePollEntrySetContaining(datePollEntryDao);
     }
 

--- a/src/main/java/mops/infrastructure/database/repositories/DatePollRepositoryImpl.java
+++ b/src/main/java/mops/infrastructure/database/repositories/DatePollRepositoryImpl.java
@@ -88,7 +88,6 @@ public class DatePollRepositoryImpl implements DatePollRepository {
 
     /**
      * Speichert ein DatePoll Aggregat.
-     *
      * @param datePoll Zu speichernde DatePoll
      */
     @Override

--- a/src/main/java/mops/infrastructure/database/repositories/DatePollRepositoryImpl.java
+++ b/src/main/java/mops/infrastructure/database/repositories/DatePollRepositoryImpl.java
@@ -78,7 +78,7 @@ public class DatePollRepositoryImpl implements DatePollRepository {
      * @param datePoll Zu speichernde DatePoll
      */
     @Override
-    @SuppressWarnings({"PMD.LawOfDemeter"})
+    @SuppressWarnings({"PMD.LawOfDemeter", "PMD.AvoidDuplicateLiterals"})
     public void save(DatePoll datePoll) {
         final Set<GroupDao> groupDaos = datePoll.getGroups().stream()
                 .map(GroupId::getId)
@@ -92,14 +92,14 @@ public class DatePollRepositoryImpl implements DatePollRepository {
         //Save PollStatus for each User ...
         saveDatePollStatus(datePoll, datePollDao);
     }
-
+    @SuppressWarnings({"PMD.LawOfDemeter", "PMD.DataflowAnomalyAnalysis"})
     private void saveDatePollStatus(DatePoll datePoll, DatePollDao datePollDao) {
         final Map<UserId, PollStatus> votingRecord = datePoll.getRecordAndStatus().getVotingRecord();
         votingRecord.forEach((userId, pollStatus) -> {
-            DatePollStatusDaoKey nextStatusKey = new DatePollStatusDaoKey(
+            final DatePollStatusDaoKey nextStatusKey = new DatePollStatusDaoKey(
                     userId.getId(),
                     datePoll.getPollLink().getLinkUUIDAsString());
-            DatePollStatusDao datePollStatusDao = new DatePollStatusDao(
+            final DatePollStatusDao datePollStatusDao = new DatePollStatusDao(
                     nextStatusKey,
                     DaoOfModelUtil.userDaoOf(userId),
                     datePollDao,
@@ -108,17 +108,18 @@ public class DatePollRepositoryImpl implements DatePollRepository {
             datePollStatusJpaRepository.save(datePollStatusDao);
         });
     }
-
+    @SuppressWarnings({"PMD.LawOfDemeter", "PMD.DataflowAnomalyAnalysis"})
     private void checkDatePollBallotsForVotes(Set<DatePollBallot> datePollBallots, DatePoll datePoll) {
-        for (DatePollBallot datePollBallot:datePollBallots
+        for (final DatePollBallot targetBallot:datePollBallots
              ) {
-            if (datePollBallot.getSelectedEntriesYes().size() != 0) {
-                setVoteForTargetUserAndEntry(datePollBallot.getSelectedEntriesYes(),
+            if (targetBallot.getSelectedEntriesYes().size() != 0) {
+                setVoteForTargetUserAndEntry(targetBallot.getSelectedEntriesYes(),
                         datePoll,
-                        datePollBallot.getUser());
+                        targetBallot.getUser());
             }
         }
     }
+    @SuppressWarnings({"PMD.LawOfDemeter"})
     private void setVoteForTargetUserAndEntry(Set<DatePollEntry> datePollEntries, DatePoll datePoll, UserId user) {
         datePollEntries.forEach(targetEntry -> datePollEntryRepositoryManager
                 .userVotesForDatePollEntry(user,

--- a/src/main/java/mops/infrastructure/database/repositories/DatePollRepositoryImpl.java
+++ b/src/main/java/mops/infrastructure/database/repositories/DatePollRepositoryImpl.java
@@ -94,12 +94,10 @@ public class DatePollRepositoryImpl implements DatePollRepository {
         }
     }
     private void setVoteForTargetUserAndEntry(Set<DatePollEntry> datePollEntries, DatePoll datePoll, UserId user) {
-        datePollEntries.forEach(targetEntry -> {
-            datePollEntryRepositoryManager
-                    .userVotesForDatePollEntry(user,
-                            datePoll.getPollLink(),
-                            targetEntry);
-        });
+        datePollEntries.forEach(targetEntry -> datePollEntryRepositoryManager
+                .userVotesForDatePollEntry(user,
+                        datePoll.getPollLink(),
+                        targetEntry));
     }
     /**
      * Lädt alle DatePolls in denen ein Nutzer teilnimmt.

--- a/src/main/java/mops/infrastructure/database/repositories/DatePollRepositoryImpl.java
+++ b/src/main/java/mops/infrastructure/database/repositories/DatePollRepositoryImpl.java
@@ -51,6 +51,19 @@ public class DatePollRepositoryImpl implements DatePollRepository {
     }
 
     /**
+     * Die Methode läd alle DatePollDaos eines bestimmten Users aus der Datenbank und
+     * wandelt diese zu DatePolls um.
+     * @param userId Der User fuer den alle DatePolls aus der Datenbank geladen werden.
+     * @return Das Set der DatePoll Objekte.
+     */
+    @SuppressWarnings({"PMD.LawOfDemeter", "PMD.AvoidDuplicateLiterals"})
+    public Set<DatePoll> findDatePollsByUser(UserId userId) {
+        final Set<DatePollDao> targetDatePollDaos = datePollJpaRepository.findAllDatePollsOfTargetUser(userId.getId());
+        return targetDatePollDaos.stream()
+                .map(ModelOfDaoUtil::pollOf)
+                .collect(Collectors.toSet());
+    }
+    /**
      * Gibt das zugehoerige DatePollDao Objekt in der Datenbank zurueck.
      * @param link DatePoll Identifier.
      * @return DatePollDao
@@ -68,6 +81,7 @@ public class DatePollRepositoryImpl implements DatePollRepository {
     public Optional<DatePoll> load(PollLink link) {
         final DatePollDao loaded = datePollJpaRepository
                 .findDatePollDaoByLink(link.getLinkUUIDAsString());
+        //TODO: DatePollBallots hinzufuegen?
         final DatePoll targetDatePoll = ModelOfDaoUtil.pollOf(loaded);
         return Optional.of(targetDatePoll);
     }

--- a/src/main/java/mops/infrastructure/database/repositories/DomainGroupRepositoryImpl.java
+++ b/src/main/java/mops/infrastructure/database/repositories/DomainGroupRepositoryImpl.java
@@ -23,9 +23,9 @@ public class DomainGroupRepositoryImpl implements DomainGroupRepository {
     }
 
     /**
-     * ...
-     * @param groupId ...
-     * @return ...
+     * Die Methode soll falls vorhanden eine Gruppe aus der Datenbank laden.
+     * @param groupId ID der Gruppe, welche aus der Datenbank geladen werden soll.
+     * @return Die Gruppe aus der Datenbank.
      */
     @SuppressWarnings({"PMD.LawOfDemeter"})
     @Override
@@ -42,8 +42,8 @@ public class DomainGroupRepositoryImpl implements DomainGroupRepository {
     }
 
     /**
-     * ...
-     * @param group ...
+     * Die Methode speichert die Gruppe in die Datenbank.
+     * @param group Die zu speichernde Gruppe.
      */
     @Override
     public void save(Group group) {

--- a/src/main/java/mops/infrastructure/database/repositories/QuestionPollEntryRepositoryManager.java
+++ b/src/main/java/mops/infrastructure/database/repositories/QuestionPollEntryRepositoryManager.java
@@ -1,0 +1,23 @@
+package mops.infrastructure.database.repositories;
+
+import mops.infrastructure.database.daos.questionpoll.QuestionPollEntryDao;
+import mops.infrastructure.database.repositories.interfaces.QuestionPollEntryJpaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class QuestionPollEntryRepositoryManager {
+    private final transient QuestionPollEntryJpaRepository questionPollEntryJpaRepository;
+    @Autowired
+    public QuestionPollEntryRepositoryManager(
+            QuestionPollEntryJpaRepository questionPollEntryJpaRepository
+            ) {
+        this.questionPollEntryJpaRepository = questionPollEntryJpaRepository;
+    }
+    /**
+     * @param questionPollEntryDaoPollEntryDao ...
+     */
+    public void save(QuestionPollEntryDao questionPollEntryDaoPollEntryDao) {
+        questionPollEntryJpaRepository.save(questionPollEntryDaoPollEntryDao);
+    }
+}

--- a/src/main/java/mops/infrastructure/database/repositories/QuestionPollEntryRepositoryManager.java
+++ b/src/main/java/mops/infrastructure/database/repositories/QuestionPollEntryRepositoryManager.java
@@ -1,23 +1,61 @@
 package mops.infrastructure.database.repositories;
 
+import mops.domain.models.PollLink;
+import mops.domain.models.questionpoll.QuestionPollEntry;
+import mops.domain.models.user.UserId;
+import mops.infrastructure.database.daos.UserDao;
+import mops.infrastructure.database.daos.questionpoll.QuestionPollDao;
 import mops.infrastructure.database.daos.questionpoll.QuestionPollEntryDao;
 import mops.infrastructure.database.repositories.interfaces.QuestionPollEntryJpaRepository;
+import mops.infrastructure.database.repositories.interfaces.QuestionPollJpaRepository;
+import mops.infrastructure.database.repositories.interfaces.UserJpaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class QuestionPollEntryRepositoryManager {
     private final transient QuestionPollEntryJpaRepository questionPollEntryJpaRepository;
+    private final transient QuestionPollJpaRepository questionPollJpaRepository;
+    private final transient UserJpaRepository userJpaRepository;
     @Autowired
     public QuestionPollEntryRepositoryManager(
-            QuestionPollEntryJpaRepository questionPollEntryJpaRepository
-            ) {
+            QuestionPollEntryJpaRepository questionPollEntryJpaRepository,
+            QuestionPollJpaRepository questionPollJpaRepository,
+            UserJpaRepository userJpaRepository) {
         this.questionPollEntryJpaRepository = questionPollEntryJpaRepository;
+        this.questionPollJpaRepository = questionPollJpaRepository;
+        this.userJpaRepository = userJpaRepository;
     }
     /**
      * @param questionPollEntryDaoPollEntryDao ...
      */
     public void save(QuestionPollEntryDao questionPollEntryDaoPollEntryDao) {
         questionPollEntryJpaRepository.save(questionPollEntryDaoPollEntryDao);
+    }
+
+    /**
+     * Die Methode dient dazu ein "Yes" vote fuer ein QuestionPollEntry abgeben zu koennen.
+     * Es wird das zugehoerige QuestionPollDao geladen.
+     * Es wird das zugehoerige QuestionPollEntryDao geladen.
+     * Es wird der zugehoerige User geladen.
+     * @param userId Der User der abstimmt.
+     * @param pollLink zugehoeriger QuestionPoll.
+     * @param questionPollEntry Vorschlag fuer den abgestimmt wird.
+     */
+    @SuppressWarnings({"PMD.LawOfDemeter"})
+    public void userVotesForQuestionPollEntry(UserId userId, PollLink pollLink, QuestionPollEntry questionPollEntry) {
+        final QuestionPollEntryDao targetQuestionPollEntryDao = findQuestionPollEntryDao(pollLink, questionPollEntry);
+        final UserDao currentUserDao = userJpaRepository.getOne(userId.getId());
+        targetQuestionPollEntryDao.getUserVotesFor().add(currentUserDao);
+        currentUserDao.getQuestionPollEntrySet().add(targetQuestionPollEntryDao);
+        userJpaRepository.save(currentUserDao);
+        questionPollEntryJpaRepository.save(targetQuestionPollEntryDao);
+    }
+
+    private QuestionPollEntryDao findQuestionPollEntryDao(PollLink pollLink, QuestionPollEntry questionPollEntry) {
+        final QuestionPollDao targetQuestionPollDao = questionPollJpaRepository
+                .findQuestionPollDaoByLink(pollLink.getLinkUUIDAsString());
+        return questionPollEntryJpaRepository.findByQuestionPollAndEntryName(
+                targetQuestionPollDao, questionPollEntry.getTitle());
     }
 }

--- a/src/main/java/mops/infrastructure/database/repositories/QuestionPollEntryRepositoryManager.java
+++ b/src/main/java/mops/infrastructure/database/repositories/QuestionPollEntryRepositoryManager.java
@@ -27,10 +27,11 @@ public class QuestionPollEntryRepositoryManager {
         this.userJpaRepository = userJpaRepository;
     }
     /**
-     * @param questionPollEntryDaoPollEntryDao ...
+     * Die Methode speichert ein QuestionPollEntryDao in die Datenbank.
+     * @param questionPollEntryDao Das zugehoerige QuestionPollEntryDao.
      */
-    public void save(QuestionPollEntryDao questionPollEntryDaoPollEntryDao) {
-        questionPollEntryJpaRepository.save(questionPollEntryDaoPollEntryDao);
+    public void save(QuestionPollEntryDao questionPollEntryDao) {
+        questionPollEntryJpaRepository.save(questionPollEntryDao);
     }
 
     /**
@@ -44,7 +45,7 @@ public class QuestionPollEntryRepositoryManager {
      */
     @SuppressWarnings({"PMD.LawOfDemeter"})
     public void userVotesForQuestionPollEntry(UserId userId, PollLink pollLink, QuestionPollEntry questionPollEntry) {
-        final QuestionPollEntryDao targetQuestionPollEntryDao = findQuestionPollEntryDao(pollLink, questionPollEntry);
+        final QuestionPollEntryDao targetQuestionPollEntryDao = loadQuestionPollEntryDao(pollLink, questionPollEntry);
         final UserDao currentUserDao = userJpaRepository.getOne(userId.getId());
         targetQuestionPollEntryDao.getUserVotesFor().add(currentUserDao);
         currentUserDao.getQuestionPollEntrySet().add(targetQuestionPollEntryDao);
@@ -52,7 +53,7 @@ public class QuestionPollEntryRepositoryManager {
         questionPollEntryJpaRepository.save(targetQuestionPollEntryDao);
     }
 
-    private QuestionPollEntryDao findQuestionPollEntryDao(PollLink pollLink, QuestionPollEntry questionPollEntry) {
+    private QuestionPollEntryDao loadQuestionPollEntryDao(PollLink pollLink, QuestionPollEntry questionPollEntry) {
         final QuestionPollDao targetQuestionPollDao = questionPollJpaRepository
                 .findQuestionPollDaoByLink(pollLink.getLinkUUIDAsString());
         return questionPollEntryJpaRepository.findByQuestionPollAndEntryName(

--- a/src/main/java/mops/infrastructure/database/repositories/QuestionPollRepositoryImpl.java
+++ b/src/main/java/mops/infrastructure/database/repositories/QuestionPollRepositoryImpl.java
@@ -1,6 +1,7 @@
 package mops.infrastructure.database.repositories;
 
 import mops.domain.models.PollLink;
+
 import mops.domain.models.group.GroupId;
 import mops.domain.models.questionpoll.QuestionPoll;
 import mops.domain.models.user.UserId;
@@ -59,7 +60,6 @@ public class QuestionPollRepositoryImpl implements QuestionPollRepository {
                 .collect(Collectors.toSet());
         questionPollJpaRepository.save(DaoOfModelUtil.pollDaoOf(questionPoll, groupDaos));
     }
-
     /**
      * Lädt alle QuestionPolls in denen ein Nutzer Teilnimmt.
      * @param userId Der User, welcher an den QuestionPolls teilnimmt.
@@ -73,7 +73,7 @@ public class QuestionPollRepositoryImpl implements QuestionPollRepository {
         final Set<QuestionPollDao> questionPollDaosFromUser = new HashSet<>();
         groupDaos.stream()
                 .map(questionPollJpaRepository::findByGroupDaosContaining)
-                .map(questionPollDaosFromUser::addAll);
+                .forEach(questionPollDaosFromUser::addAll);
         final Set<QuestionPoll> targetQuestionPolls = new HashSet<>();
         questionPollDaosFromUser.forEach(
                 datePollDao -> targetQuestionPolls.add(ModelOfDaoUtil.pollOf(datePollDao)));

--- a/src/main/java/mops/infrastructure/database/repositories/QuestionPollRepositoryImpl.java
+++ b/src/main/java/mops/infrastructure/database/repositories/QuestionPollRepositoryImpl.java
@@ -1,9 +1,10 @@
 package mops.infrastructure.database.repositories;
 
 import mops.domain.models.PollLink;
-
 import mops.domain.models.group.GroupId;
 import mops.domain.models.questionpoll.QuestionPoll;
+import mops.domain.models.questionpoll.QuestionPollBallot;
+import mops.domain.models.questionpoll.QuestionPollEntry;
 import mops.domain.models.user.UserId;
 import mops.domain.repositories.QuestionPollRepository;
 import mops.infrastructure.database.daos.GroupDao;
@@ -17,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -26,12 +28,15 @@ public class QuestionPollRepositoryImpl implements QuestionPollRepository {
 
     private final transient QuestionPollJpaRepository questionPollJpaRepository;
     private final transient GroupJpaRepository groupJpaRepository;
+    private final transient QuestionPollEntryRepositoryManager questionPollEntryRepositoryManager;
 
     @Autowired
     public QuestionPollRepositoryImpl(QuestionPollJpaRepository questionPollJpaRepository,
-                                      GroupJpaRepository groupJpaRepository) {
+                                      GroupJpaRepository groupJpaRepository,
+                                      QuestionPollEntryRepositoryManager questionPollEntryRepositoryManager) {
         this.questionPollJpaRepository = questionPollJpaRepository;
         this.groupJpaRepository = groupJpaRepository;
+        this.questionPollEntryRepositoryManager = questionPollEntryRepositoryManager;
     }
 
     /**
@@ -51,7 +56,7 @@ public class QuestionPollRepositoryImpl implements QuestionPollRepository {
      * @param questionPoll Zu speicherndes QuestionPoll
      */
     @Override
-    @SuppressWarnings({"PMD.LawOfDemeter"})
+    @SuppressWarnings({"PMD.LawOfDemeter", "PMD.AvoidDuplicateLiterals"})
     public void save(QuestionPoll questionPoll) {
         final Set<GroupDao> groupDaos = questionPoll.getGroups().stream()
                 .map(GroupId::getId)
@@ -59,6 +64,24 @@ public class QuestionPollRepositoryImpl implements QuestionPollRepository {
                 .map(Optional::orElseThrow)
                 .collect(Collectors.toSet());
         questionPollJpaRepository.save(DaoOfModelUtil.pollDaoOf(questionPoll, groupDaos));
+        checkQuestionPollBallotsForVotes(questionPoll.getBallots(), questionPoll);
+    }
+    @SuppressWarnings({"PMD.LawOfDemeter", "PMD.DataflowAnomalyAnalysis"})
+    private void checkQuestionPollBallotsForVotes(Set<QuestionPollBallot> questionPollBallots,
+                                                  QuestionPoll questionPoll) {
+        for (final QuestionPollBallot targetBallot:questionPollBallots) {
+            if (targetBallot.getSelectedEntries().size() != 0) {
+                setVoteForTargetUserAndEntry(targetBallot.getSelectedEntries(), questionPoll, targetBallot.getUser());
+            }
+        }
+    }
+    @SuppressWarnings({"PMD.LawOfDemeter"})
+    private void setVoteForTargetUserAndEntry(List<QuestionPollEntry> questionPollEntries,
+                                              QuestionPoll questionPoll, UserId user) {
+        questionPollEntries.forEach(targetEntry -> questionPollEntryRepositoryManager
+                .userVotesForQuestionPollEntry(user,
+                        questionPoll.getPollLink(),
+                        targetEntry));
     }
     /**
      * Lädt alle QuestionPolls in denen ein Nutzer Teilnimmt.

--- a/src/main/java/mops/infrastructure/database/repositories/interfaces/DatePollJpaRepository.java
+++ b/src/main/java/mops/infrastructure/database/repositories/interfaces/DatePollJpaRepository.java
@@ -3,6 +3,7 @@ import mops.infrastructure.database.daos.GroupDao;
 import mops.infrastructure.database.daos.UserDao;
 import mops.infrastructure.database.daos.datepoll.DatePollDao;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Set;
 
@@ -10,4 +11,11 @@ public interface DatePollJpaRepository extends JpaRepository<DatePollDao, String
     DatePollDao findDatePollDaoByLink(String link);
     DatePollDao findByCreatorUserDao(UserDao userDao);
     Set<DatePollDao> findByGroupDaosContaining(GroupDao targetGroup);
+    @Query(
+            value = "select a.* from datepoll as a, datepoll_group_daos b, usergroup_user_daos c "
+                    + "where a.link = b.date_poll_daos_link and b.group_daos_id = c.group_set_id "
+                    + "and c.user_daos_id = ?1",
+            nativeQuery = true
+    )
+    Set<DatePollDao> findAllDatePollsOfTargetUser(String userId);
 }

--- a/src/main/java/mops/infrastructure/database/repositories/interfaces/QuestionPollEntryJpaRepository.java
+++ b/src/main/java/mops/infrastructure/database/repositories/interfaces/QuestionPollEntryJpaRepository.java
@@ -1,5 +1,6 @@
 package mops.infrastructure.database.repositories.interfaces;
 
+import mops.infrastructure.database.daos.TimespanDao;
 import mops.infrastructure.database.daos.questionpoll.QuestionPollDao;
 import mops.infrastructure.database.daos.questionpoll.QuestionPollEntryDao;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ import java.util.Set;
 
 public interface QuestionPollEntryJpaRepository extends JpaRepository<QuestionPollEntryDao, Long> {
     Set<QuestionPollEntryDao> findByQuestionPoll(QuestionPollDao questionPollDao);
+    QuestionPollEntryDao findByQuestionPollAndTimespanDao(QuestionPollDao questionPollDao, TimespanDao timespanDao);
 }

--- a/src/main/java/mops/infrastructure/database/repositories/interfaces/QuestionPollEntryJpaRepository.java
+++ b/src/main/java/mops/infrastructure/database/repositories/interfaces/QuestionPollEntryJpaRepository.java
@@ -8,4 +8,5 @@ import java.util.Set;
 
 public interface QuestionPollEntryJpaRepository extends JpaRepository<QuestionPollEntryDao, Long> {
     Set<QuestionPollEntryDao> findByQuestionPoll(QuestionPollDao questionPollDao);
+    QuestionPollEntryDao findByQuestionPollAndEntryName(QuestionPollDao questionPoll, String title);
 }

--- a/src/main/java/mops/infrastructure/database/repositories/interfaces/QuestionPollEntryJpaRepository.java
+++ b/src/main/java/mops/infrastructure/database/repositories/interfaces/QuestionPollEntryJpaRepository.java
@@ -1,6 +1,5 @@
 package mops.infrastructure.database.repositories.interfaces;
 
-import mops.infrastructure.database.daos.TimespanDao;
 import mops.infrastructure.database.daos.questionpoll.QuestionPollDao;
 import mops.infrastructure.database.daos.questionpoll.QuestionPollEntryDao;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +8,4 @@ import java.util.Set;
 
 public interface QuestionPollEntryJpaRepository extends JpaRepository<QuestionPollEntryDao, Long> {
     Set<QuestionPollEntryDao> findByQuestionPoll(QuestionPollDao questionPollDao);
-    QuestionPollEntryDao findByQuestionPollAndTimespanDao(QuestionPollDao questionPollDao, TimespanDao timespanDao);
 }

--- a/src/test/java/mops/database/DatePollsFromUser.java
+++ b/src/test/java/mops/database/DatePollsFromUser.java
@@ -1,0 +1,95 @@
+package mops.database;
+
+import mops.MopsApplication;
+import mops.config.H2DatabaseConfigForTests;
+import mops.domain.models.PollLink;
+import mops.domain.models.Timespan;
+import mops.domain.models.datepoll.DatePoll;
+import mops.domain.models.datepoll.DatePollBuilder;
+import mops.domain.models.datepoll.DatePollConfig;
+import mops.domain.models.datepoll.DatePollEntry;
+import mops.domain.models.datepoll.DatePollMetaInf;
+import mops.domain.models.group.Group;
+import mops.domain.models.group.GroupId;
+import mops.domain.models.user.UserId;
+import mops.infrastructure.database.repositories.DatePollRepositoryImpl;
+import mops.infrastructure.database.repositories.DomainGroupRepositoryImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {MopsApplication.class, H2DatabaseConfigForTests.class})
+@Transactional
+@SuppressWarnings({"PMD.LawOfDemeter", "PMD.AtLeastOneConstructor"})
+public class DatePollsFromUser {
+    @Autowired
+    private transient DatePollRepositoryImpl datePollRepo;
+    private final transient Random random = new Random();
+    @Autowired
+    private transient DomainGroupRepositoryImpl domainGroupRepository;
+    @SuppressWarnings("checkstyle:MagicNumber")
+    @Test
+    public void userOneHasThreeDatePolls() {
+        final DatePoll firstDatePoll = createDatePoll(4, 5, "datepoll 1", "1");
+        final DatePoll secondDatePoll = createDatePoll(4, 5, "datepoll 1", "1");
+        final DatePoll thirdDatePoll = createDatePoll(4, 5, "datepoll 1", "1");
+
+        datePollRepo.save(firstDatePoll);
+        datePollRepo.save(secondDatePoll);
+        datePollRepo.save(thirdDatePoll);
+        assertThat(datePollRepo.findDatePollsByUser(new UserId("1")).size()).isEqualTo(3);
+    }
+
+    /**
+     * Beispiel Daten fuer ein DatePoll Objekt.
+     * @param users Anzahl an Teilnehmern.
+     * @param pollentries Anzahl an DatePollEntry Objekten.
+     * @param title Der Titel des DatePoll Objektes.
+     * @param groupId Die zugehoerige Gruppen ID.
+     * @return DatePoll Das zu erstellende DatePoll Objekt.
+     */
+    @SuppressWarnings("checkstyle:MagicNumber")
+    private DatePoll createDatePoll(int users, int pollentries, String title, String groupId) {
+        final DatePoll datePoll;
+        final Timespan timespan = new Timespan(LocalDateTime.now(), LocalDateTime.now().plusDays(10));
+        final DatePollMetaInf datePollMetaInf = new DatePollMetaInf(title, "Testing", "Uni", timespan);
+        final UserId creator = new UserId(Integer.toString(random.nextInt()));
+        final DatePollConfig datePollConfig = new DatePollConfig();
+        final PollLink datePollLink = new PollLink();
+
+        final Set<UserId> participants = new HashSet<>();
+        IntStream.range(0, users).forEach(i -> participants.add(new UserId(Integer.toString(i))));
+
+        final Set<DatePollEntry> pollEntries = new HashSet<>();
+        IntStream.range(0, pollentries).forEach(i -> pollEntries.add(new DatePollEntry(
+                new Timespan(LocalDateTime.now().plusDays(i), LocalDateTime.now().plusDays(10 + i))
+        )));
+        final Group group = new Group(new GroupId(groupId), participants);
+
+        datePoll = new DatePollBuilder()
+                .datePollMetaInf(datePollMetaInf)
+                .creator(creator)
+                .datePollConfig(datePollConfig)
+                .datePollEntries(pollEntries)
+                .participatingGroups(Set.of(group.getId()))
+                .datePollLink(datePollLink)
+                .build();
+        domainGroupRepository.save(group);
+        return datePoll;
+    }
+
+}


### PR DESCRIPTION
Hinzufügen einiger Methoden in den Repositories. Vor allem wurde die save Methode für DatePolls erweitert. Nun wird das Set<DatePollBallot> aus DatePoll bearbeitet und die Stimmen der User entsprechend ausgewertet. Außerdem wurde eine Native Query hinzugefuegt die ein Set<DatePollDao> zurueck gibt, welche zu einem User gehören (Join über die Group Tabelle).

Tests wurden auch hinzugefuegt + gradlew check läuft durch.